### PR TITLE
only require aws-sdk-core

### DIFF
--- a/aws-keychain-util.gemspec
+++ b/aws-keychain-util.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('ruby-keychain', '~> 0.2.0')
   gem.add_dependency('highline')
-  gem.add_dependency('aws-sdk', '> 2.0')
+  gem.add_dependency('aws-sdk-core', '> 2.0')
   gem.add_development_dependency 'rubocop'
   gem.add_development_dependency 'rake'
 end

--- a/bin/aws-creds
+++ b/bin/aws-creds
@@ -9,7 +9,7 @@ require 'highline'
 require 'keychain'
 require 'json'
 require 'aws_keychain_util'
-require 'aws-sdk'
+require 'aws-sdk-core'
 
 trap('SIGINT') do
   puts

--- a/lib/aws-keychain-util/credential_provider.rb
+++ b/lib/aws-keychain-util/credential_provider.rb
@@ -1,6 +1,6 @@
-require 'aws-sdk'
+require 'aws-sdk-core'
 require 'keychain'
-require 'aws-keychain-util'
+require 'aws_keychain_util'
 
 module AwsKeychainUtil
   # class to automatically grab AWS credentials from your keychain


### PR DESCRIPTION
since the rest of aws-sdk isn't necessary